### PR TITLE
Upgrading the MLKit library to the one in the official documentation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,5 +57,5 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     api project(":react-native-vision-camera")
     implementation "androidx.camera:camera-core:1.1.0-alpha06"
-    implementation 'com.google.mlkit:image-labeling:17.0.5'
+    implementation 'com.google.mlkit:image-labeling:17.0.7'
 }


### PR DESCRIPTION
If you use this library with others vision camera plugins like vision-camera-ocr, you will have some conflicts. To fix this we should use in all the plugins the last version from the MLKit from the official documentation: [https://developers.google.com/ml-kit/vision/image-labeling/android](https://developers.google.com/ml-kit/vision/image-labeling/android)